### PR TITLE
Feat/optimize ecs resources

### DIFF
--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -23,9 +23,9 @@ resource "aws_lb_target_group" "backend_target_group" {
     path                = "/api/v1/health"
     protocol            = "HTTP"
     port                = "traffic-port"
-    timeout             = 120
-    interval            = 200
-    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 15
+    unhealthy_threshold = 3
     healthy_threshold   = 2
     matcher             = "200-499"
   }

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -106,3 +106,4 @@ resource "aws_s3_bucket_public_access_block" "tfstate" {
 # }
 #   EOF
 # }
+

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -191,7 +191,7 @@ resource "aws_autoscaling_group" "ecs-autoscaling-group" {
   health_check_type         = "EC2"
   protect_from_scale_in     = false
   health_check_grace_period = 90
-  desired_capacity          = 2
+  desired_capacity          = 3
   termination_policies      = ["OldestLaunchConfiguration"]
 
   enabled_metrics = [
@@ -484,8 +484,8 @@ resource "aws_ecs_task_definition" "django_task" {
     }],
     essential = true,
     command   = ["/start"],
-    cpu       = 512,
-    memory    = 1024,
+    cpu       = 1024,
+    memory    = 2048,
 
 
     logConfiguration = {
@@ -513,7 +513,8 @@ resource "aws_ecs_task_definition" "django_task" {
       image     = "${var.django_ecr_url}:latest",
       essential = true,
       command   = ["/start-celeryworker"],
-      memory    = 512,
+      cpu       = 512,
+      memory    = 1024,
       logConfiguration = {
         logDriver = "awslogs",
         options = {
@@ -538,6 +539,7 @@ resource "aws_ecs_task_definition" "django_task" {
       image     = "${var.django_ecr_url}:latest",
       essential = true,
       command   = ["/start-celerybeat"],
+      cpu       = 256,
       memory    = 256,
       # logConfiguration = {
       #   logDriver = "awslogs",

--- a/providers.tf
+++ b/providers.tf
@@ -33,10 +33,10 @@ provider "aws" {
 terraform {
   backend "s3" {
     #bucket         = "${aws_s3_bucket.tfstate.id}"
-    bucket         = "pfc-tfs"
-    key            = "terraform.tfstate"
-    region         = "ap-south-1"
-    encrypt        = true
-    use_lockfile   = true
+    bucket       = "pfc-tfs"
+    key          = "terraform.tfstate"
+    region       = "ap-south-1"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -29,3 +29,14 @@ provider "aws" {
   }
 
 }
+
+terraform {
+  backend "s3" {
+    #bucket         = "${aws_s3_bucket.tfstate.id}"
+    bucket         = "pfc-tfs"
+    key            = "terraform.tfstate"
+    region         = "ap-south-1"
+    encrypt        = true
+    use_lockfile   = true
+  }
+}


### PR DESCRIPTION
## Summary
Configures remote Terraform state, tightens ALB health checks for faster deploys, and increases ECS task CPU/memory.
## Changes
### Terraform backend (`providers.tf`)
- Added root `terraform { backend "s3" }` so state is stored remotely (backend blocks in child modules are ignored)
- Bucket: `pfc-tfs`, key: `terraform.tfstate`, region: `ap-south-1`
- Encryption and S3 lockfile enabled
### ALB (`modules/alb/main.tf`)
- Target group health check:
  - `timeout`: 120s → 5s
  - `interval`: 200s → 15s
  - `unhealthy_threshold`: 2 → 3
- New tasks should register healthy in ~30s instead of ~400s
### ECS (`modules/ecs/main.tf`)
- **django**: CPU 512 → 1024, memory 1024 → 2048
- **celeryworker**: CPU 512, memory 512 → 1024
- **celerybeat**: CPU 256 (memory unchanged at 256)
- ASG `desired_capacity`: 2 → 3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scaled up backend compute resources and autoscaling capacity.
  * Configured remote state backend for infrastructure management.
  * Fine-tuned health check monitoring settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Project-Fitness-Co/pfc-ecs-iac/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->